### PR TITLE
Add landing page sections

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -2,7 +2,7 @@ body {
   font-family: Arial, sans-serif;
   background-color: #f9f9f9;
   text-align: center;
-  padding: 50px;
+  padding-top: 60px;
 }
 
 .login-btn {
@@ -14,5 +14,20 @@ body {
   padding: 10px 15px;
   text-decoration: none;
   border-radius: 4px;
+}
+
+header {
+  background-image: url('/img/hero.jpg');
+  background-size: cover;
+  background-position: center;
+  color: #333;
+}
+
+section {
+  text-align: left;
+}
+
+section h2 {
+  font-size: 2rem;
 }
 

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -7,8 +7,47 @@
 </head>
 <body>
   <a class="login-btn" href="/login">Ingresar</a>
-  <h1><%= titulo %></h1>
-  <p>Bienvenido a tu monolito con Node.js y EJS</p>
+
+  <!-- Hero -->
+  <header class="bg-light py-5 mb-5 text-center">
+    <div class="container">
+      <h1 class="display-4">Persianas y Cortinas</h1>
+      <p class="lead">Soluciones a medida directamente de fábrica</p>
+    </div>
+  </header>
+
+  <!-- About -->
+  <section id="about" class="container mb-5">
+    <h2 class="mb-3">¿Quiénes somos?</h2>
+    <p>Somos fabricantes de persianas y cortinas comprometidos con la calidad y el servicio personalizado.</p>
+  </section>
+
+  <!-- Features -->
+  <section id="features" class="bg-light py-5 mb-5">
+    <div class="container">
+      <div class="row text-center">
+        <div class="col-md-4 mb-4">
+          <h3>Variedad</h3>
+          <p>Amplio catálogo de estilos y materiales para cada espacio.</p>
+        </div>
+        <div class="col-md-4 mb-4">
+          <h3>Instalación profesional</h3>
+          <p>Nuestro equipo garantiza un montaje rápido y sin complicaciones.</p>
+        </div>
+        <div class="col-md-4 mb-4">
+          <h3>Garantía</h3>
+          <p>Respaldamos cada proyecto con garantías por escrito.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Contact -->
+  <section id="contact" class="container mb-5">
+    <h2 class="mb-3">Contacto</h2>
+    <p>Solicita una cotización vía correo a <a href="mailto:info@example.com">info@example.com</a>.</p>
+  </section>
+
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- expand landing page with hero, about, features and contact sections
- style sections via CSS
- add placeholder hero image

## Testing
- `npm start`

------
https://chatgpt.com/codex/tasks/task_b_68563e6db43083208b8cd7fef67999b5